### PR TITLE
fix top aligment in vtt

### DIFF
--- a/src/main/java/fr/noop/subtitle/vtt/VttWriter.java
+++ b/src/main/java/fr/noop/subtitle/vtt/VttWriter.java
@@ -123,7 +123,8 @@ public class VttWriter implements SubtitleWriterWithTimecode, SubtitleWriterWith
         if (cue instanceof SubtitleRegionCue) {
             VerticalAlign va = ((SubtitleRegionCue) cue).getRegion().getVerticalAlign();
             if (va == VerticalAlign.TOP) {
-                return "line:0";
+                // there is a bug in Shaka 4.X when aligned to top using "line:0"
+                return "line:0.01%";
             }
             else {
                 return "";


### PR DESCRIPTION
Shaka ui 4.X can't align to top using "line:0" or "line:0%" so we're hacking using "line:0.01%" and it works.

